### PR TITLE
Added disconnect callback.

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -65,11 +65,12 @@ class TestCollection(unittest.TestCase):
 
     @defer.inlineCallbacks
     def setUp(self):
-        model.MongoObj.mongo = yield model.txmongo.MongoConnection('127.0.0.1', 27017)
+        # model.MongoObj.mongo = yield model.txmongo.MongoConnection('127.0.0.1', 27017)
+        yield model.MongoObj.connect('127.0.0.1', 27017)
 
     @defer.inlineCallbacks
     def tearDown(self):
-        yield model.MongoObj.mongo.disconnect()
+        yield model.MongoObj.disconnect()
 
     def test_default(self):
         col = CollectionObject()

--- a/txmongoobject/model.py
+++ b/txmongoobject/model.py
@@ -526,9 +526,14 @@ class MongoObj(MongoSubObj):
         if cls.mongo is None:
             return
 
+        def _after_disconnect(x):
+            cls.mongo = None 
+
         # Returns a deferred which (hopefully) fires when all
         # connections are severed
-        return cls.mongo.disconnect()
+        closer = cls.mongo.disconnect()
+        closer.addBoth(_after_disconnect)
+        return closer
 
     def __eq__(self, other):
         ''' Comparison between this and another object. Also returns true if


### PR DESCRIPTION
Not sure if we want to fix this, but if we don't it might be best to Except when a reconnect is attempted.  (Raise an exception in MongoObj.connect if cls.mongo != None.)